### PR TITLE
Fix for decode.py for ST3 - NOT RIGHT

### DIFF
--- a/encode.py
+++ b/encode.py
@@ -157,7 +157,8 @@ class FoundationGridEncodeCommand(sublime_plugin.TextCommand):
     selections = self.view.sel()
     for selection in selections:
       # Get the HTML from the selection
-      edit = self.view.begin_edit('foundation-grid')
+      #edit = self.view.begin_edit('foundation-grid') #ST3 - Signature for begin_edit and end_edit has changed. 
+      edit = self.view.begin_edit() #ST3 - Signature for begin_edit and end_edit has changed. 
       string = self.view.substr(selection)
 
       # print "Feeding the parser:\n%s" % string


### PR DESCRIPTION
Was getting the same error here -> https://twitter.com/ZURBuniversity/status/522445801511858176

Opened the packaged up, I am new to sublime and fairly okay in Python. I googled some and came to know that the signature for begin_edit() and end_edit() has changed.

Oops, the correct code is

self.edit = edit. and not edit = self.view.begin_edit()

I am assuming here 'foundation-grid' was a token?

 Hope this helps.
